### PR TITLE
Breck/metadata

### DIFF
--- a/contracts/ERC721.sol
+++ b/contracts/ERC721.sol
@@ -70,15 +70,6 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable 
     bytes4 private constant _INTERFACE_ID_ERC721 = 0x80ac58cd;
 
     /*
-     *     bytes4(keccak256('name()')) == 0x06fdde03
-     *     bytes4(keccak256('symbol()')) == 0x95d89b41
-     *     bytes4(keccak256('tokenURI(uint256)')) == 0xc87b56dd
-     *
-     *     => 0x06fdde03 ^ 0x95d89b41 ^ 0xc87b56dd == 0x5b5e139f
-     */
-    bytes4 private constant _INTERFACE_ID_ERC721_METADATA = 0x5b5e139f;
-
-    /*
      *     bytes4(keccak256('totalSupply()')) == 0x18160ddd
      *     bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) == 0x2f745c59
      *     bytes4(keccak256('tokenByIndex(uint256)')) == 0x4f6ccce7
@@ -96,7 +87,6 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable 
 
         // register the supported interfaces to conform to ERC721 via ERC165
         _registerInterface(_INTERFACE_ID_ERC721);
-        _registerInterface(_INTERFACE_ID_ERC721_METADATA);
         _registerInterface(_INTERFACE_ID_ERC721_ENUMERABLE);
     }
 


### PR DESCRIPTION
This PR:
1. Adds an explicit mapping of `tokenMetadataURIs` and `tokenMetadataHashes`
2. Adds the `metadataURI` and `metadataHash` params to mint.
3. Adds `updateTokenMetadataURI()` function to all for the metadata uri to be changed. 
4. Registers a new ERC721 Metadata interface id in the constructor.
5. Renames some internal and external methods to be prefixed with `token`