### PR TITLE
[feature] add revokeApproval to Media.sol

### DIFF
--- a/contracts/Media.sol
+++ b/contracts/Media.sol
@@ -279,6 +279,13 @@ contract Media is ERC721Burnable {
         _burn(tokenId);
     }
 
+    function revokeApproval(uint256 tokenId)
+        public
+    {
+        require(msg.sender == getApproved(tokenId), "Media: caller not approved address");
+        _approve(address(0), tokenId);
+    }
+
     function updateTokenURI(uint256 tokenId, string memory tokenURI)
         public
         onlyApprovedOrOwner(msg.sender, tokenId)

--- a/contracts/interfaces/IMedia.sol
+++ b/contracts/interfaces/IMedia.sol
@@ -24,4 +24,15 @@ interface IMedia {
     function removeBid(uint256 tokenId) external;
 
     function acceptBid(uint256 tokenId, address bidder) external;
+
+    function permit(
+        address spender,
+        uint256 tokenId,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function revokeApproval(uint256 tokenId) external;
 }

--- a/test/Media.test.ts
+++ b/test/Media.test.ts
@@ -1043,4 +1043,38 @@ describe('Media', () => {
       expect(supportsId).eq(false);
     });
   });
+
+  describe('#revokeApproval', async () => {
+    let currency: string;
+
+    beforeEach(async () => {
+      await deploy();
+      currency = await deployCurrency();
+      await setupAuction(currency);
+    });
+
+    it("should revert if the caller is the owner", async() => {
+      const token = await tokenAs(ownerWallet);
+      await expect(token.revokeApproval(0)).rejectedWith("Media: caller not approved address");
+    });
+
+    it("should revert if the caller is the creator", async() => {
+      const token = await tokenAs(creatorWallet);
+      await expect(token.revokeApproval(0)).rejectedWith("Media: caller not approved address");
+    });
+
+    it("should revert if the caller is neither owner, creator, or approver", async() => {
+      const token = await tokenAs(otherWallet);
+      await expect(token.revokeApproval(0)).rejectedWith("Media: caller not approved address");
+    });
+
+    it("should revoke the approval for token id if caller is approved address", async () => {
+      const token = await tokenAs(ownerWallet);
+      await token.approve(otherWallet.address, 0);
+      const otherToken = await tokenAs(otherWallet);
+      await expect(otherToken.revokeApproval(0)).fulfilled;
+      const approved = await token.getApproved(0);
+      expect(approved).eq(ethers.constants.AddressZero);
+    });
+  })
 });


### PR DESCRIPTION
Allow an approved address to revoke their own approval. 

Owner / Approved For All addresses should use `approve(address(0), tokenId)` for the same functionality.