### PR TITLE
[fix] Ensure bids are only paid for by the message sender

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -27,6 +27,8 @@ contract Market {
         address currency;
         // Address of the bidder
         address bidder;
+        // Address of the recipient
+        address recipient;
         // % of the next sale to award the previous owner
         Decimal.D256 sellOnFee;
     }
@@ -375,7 +377,7 @@ contract Market {
     /**
      * @dev Given a token ID and a bidder, this method transfers the value of
      * the bid to the shareholders. It also transfers the ownership of the media
-     * to the bidder. Finally, it removes the accepted bid and the current ask.
+     * to the bid recipient. Finally, it removes the accepted bid and the current ask.
      */
     function _finalizeNFTTransfer(uint256 tokenId, address bidder) private {
         Bid memory bid = _tokenBidders[tokenId][bidder];
@@ -396,7 +398,7 @@ contract Market {
             _splitShare(bidShares.prevOwner, bid.amount)
         );
 
-        Media(tokenContract).auctionTransfer(tokenId, bidder);
+        Media(tokenContract).auctionTransfer(tokenId, bid.recipient);
 
         bidShares.owner = Decimal.D256(
             uint256(100)

--- a/contracts/Media.sol
+++ b/contracts/Media.sol
@@ -227,12 +227,12 @@ contract Media is ERC721Burnable {
      * @dev Transfer the token with the given ID to a given address.
      * note: This can only be called by the auction contract specified at deployment
      */
-    function auctionTransfer(uint256 tokenId, address bidder)
+    function auctionTransfer(uint256 tokenId, address recipient)
         public
         onlyAuction
     {
         previousTokenOwners[tokenId] = ownerOf(tokenId);
-        _safeTransfer(ownerOf(tokenId), bidder, tokenId, "");
+        _safeTransfer(ownerOf(tokenId), recipient, tokenId, "");
     }
 
     function setAsk(uint256 tokenId, Market.Ask memory ask)
@@ -246,6 +246,7 @@ contract Media is ERC721Burnable {
         public
         onlyExistingToken(tokenId)
     {
+        require(msg.sender == bid.bidder, "Market: Bidder must be msg sender");
         Market(_auctionContract).setBid(tokenId, bid, msg.sender);
     }
 

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -35,6 +35,7 @@ type Bid = {
   currency: string;
   amount: BigNumberish;
   bidder: string;
+  recipient: string;
   sellOnFee: { value: BigNumberish };
 };
 
@@ -320,6 +321,7 @@ describe('Market', () => {
       amount: 100,
       currency: currency,
       bidder: bidderWallet.address,
+      recipient: otherWallet.address,
       spender: bidderWallet.address,
       sellOnFee: Decimal.new(10),
     };
@@ -396,6 +398,7 @@ describe('Market', () => {
         amount: 130000000,
         currency: currency,
         bidder: bidderWallet.address,
+        recipient: otherWallet.address,
         spender: bidderWallet.address,
         sellOnFee: Decimal.new(10),
       };

--- a/test/Media.test.ts
+++ b/test/Media.test.ts
@@ -57,6 +57,7 @@ type Bid = {
   currency: string;
   amount: BigNumberish;
   bidder: string;
+  recipient: string;
   sellOnFee: { value: BigNumberish };
 };
 
@@ -83,10 +84,15 @@ describe('Media', () => {
     currency: '0x41A322b28D0fF354040e2CbC676F0320d8c8850d',
     sellOnFee: Decimal.new(0),
   };
-  const defaultBid = (currency: string, bidder: string) => ({
+  const defaultBid = (
+    currency: string,
+    bidder: string,
+    recipient?: string
+  ) => ({
     amount: 100,
     currency,
     bidder,
+    recipient: recipient || bidder,
     sellOnFee: Decimal.new(10),
   });
 
@@ -550,6 +556,7 @@ describe('Media', () => {
           currency: currencyAddr,
           amount: 200,
           bidder: bidderWallet.address,
+          recipient: otherWallet.address,
           sellOnFee: Decimal.new(10),
         },
         1
@@ -639,7 +646,7 @@ describe('Media', () => {
       const auction = await MarketFactory.connect(auctionAddress, bidderWallet);
       const asBidder = await tokenAs(bidderWallet);
       const bid = {
-        ...defaultBid(currencyAddr, bidderWallet.address),
+        ...defaultBid(currencyAddr, bidderWallet.address, otherWallet.address),
         sellOnFee: Decimal.new(15),
       };
       await setBid(asBidder, bid, 0);
@@ -669,7 +676,7 @@ describe('Media', () => {
       expect(afterOwnerBalance).eq(beforeOwnerBalance + 80);
       expect(afterPrevOwnerBalance).eq(beforePrevOwnerBalance + 10);
       expect(afterCreatorBalance).eq(beforeCreatorBalance + 10);
-      expect(newOwner).eq(bidderWallet.address);
+      expect(newOwner).eq(otherWallet.address);
       expect(toNumWei(bidShares.owner.value)).eq(75 * 10 ** 18);
       expect(toNumWei(bidShares.prevOwner.value)).eq(15 * 10 ** 18);
       expect(toNumWei(bidShares.creator.value)).eq(10 * 10 ** 18);


### PR DESCRIPTION
This approach ensures the message sender is the one paying for the tokens while ensuring the bidder can be set to any address (so we can set the bidder address to any address that can receive NFTs. A side effect is that when a bid is replaced, the bid is refunded to whoever the bidder is, not the payer. This is because the payer is not stored anywhere. 

An alternative approach would be to extend the `Bid` struct to include a `spender` address that represents the address that paid for the bid. Any bid refunds would then be sent to the `spender` . In addition, the `removeBid` would only be callable by the `spender`, rather than the `bidder`