### PR TITLE
[feature] add bid id

### DIFF
--- a/contracts/Media.sol
+++ b/contracts/Media.sol
@@ -310,13 +310,16 @@ contract Media is ERC721Burnable, ReentrancyGuard {
         Market(marketContract).removeAsk(tokenId);
     }
 
-    function setBid(uint256 tokenId, Market.Bid memory bid)
+    function setBid(uint256 tokenId, Market.BidData memory bidData)
         public
         nonReentrant
         onlyExistingToken(tokenId)
     {
-        require(msg.sender == bid.bidder, "Market: Bidder must be msg sender");
-        Market(marketContract).setBid(tokenId, bid, msg.sender);
+        require(
+            msg.sender == bidData.bidder,
+            "Market: Bidder must be msg sender"
+        );
+        Market(marketContract).setBid(tokenId, bidData, msg.sender);
     }
 
     function removeBid(uint256 tokenId)

--- a/test/Market.test.ts
+++ b/test/Market.test.ts
@@ -11,6 +11,7 @@ import { formatUnits } from '@ethersproject/units';
 import { AddressZero, MaxUint256 } from '@ethersproject/constants';
 import { BaseErc20Factory } from '../typechain/BaseErc20Factory';
 import { Market } from '../typechain/Market';
+import { toNumWei } from './utils';
 
 chai.use(asPromised);
 
@@ -470,6 +471,7 @@ describe('Market', () => {
 
       expect(events.length).eq(1);
       const logDescription = auction.interface.parseLog(events[0]);
+      expect(toNumWei(logDescription.args.bid.id)).to.eq(0);
       expect(toNumWei(logDescription.args.tokenId)).to.eq(defaultTokenId);
       expect(toNumWei(logDescription.args.bid.amount)).to.eq(defaultBid.amount);
       expect(logDescription.args.bid.currency).to.eq(defaultBid.currency);


### PR DESCRIPTION
This PR does three things.

1. It removes the redundant delete ask in finalizeNFTTransfer.
2. It adds a monotonically increasing bid id to each media market. This id is stored as a part of the bid struct and is included in event emissions for bids. This will make it such that offchain services can uniquely identify bids by their id.
3. Adds an extra guard on accept bid to ensure the passed bid id matches the acutal bid id.